### PR TITLE
Allow users to load more search results

### DIFF
--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -10,13 +10,21 @@
       <div style="position: relative; overflow: hidden;">
         <PowerSelect
           @ariaLabel="Zoekbalk"
-          @search={{perform @searchTask}}
+          @search={{perform this.search}}
+          @options={{this.options}}
           @allowClear={{true}}
           @searchEnabled={{true}}
           @loadingMessage="Aan het laden..."
           @searchMessage="Typ om te zoeken"
           @noMatchesMessage="Geen resultaten"
           @destination="ember-test"
+          @optionsComponent={{component
+            "infinite-select/options"
+            canLoadMore=this.searchData.canLoadMoreSearchResults
+            loadMore=(perform this.loadMoreSearchResults)
+            isLoadingMore=this.loadMoreSearchResults.isRunning
+          }}
+          @registerAPI={{this.registerAPI}}
           @onChange={{@appendBestuurseenheid}} as |eenheid|>
           {{#unless (contains eenheid @bestuurseenhedenLijst) }}
            {{eenheid.naam}} ({{eenheid.classificatie.label}})

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -26,7 +26,7 @@
           }}
           @registerAPI={{this.registerAPI}}
           @onChange={{@appendBestuurseenheid}} as |eenheid|>
-          {{#unless (contains eenheid @bestuurseenhedenLijst) }}
+          {{#unless (includes eenheid @bestuurseenhedenLijst) }}
            {{eenheid.naam}} ({{eenheid.classificatie.label}})
           {{/unless}}
         </PowerSelect>

--- a/app/components/bestuurseenheid-toevoegen.js
+++ b/app/components/bestuurseenheid-toevoegen.js
@@ -1,0 +1,83 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { timeout } from 'ember-concurrency';
+import { dropTask, restartableTask } from 'ember-concurrency-decorators';
+
+export default class BestuurseenheidToevoegenComponent extends Component {
+  @service store;
+
+  @tracked selected = null;
+  @tracked searchData;
+
+  get isSearching() {
+    return Boolean(this.searchData);
+  }
+
+  get options() {
+    return this.isSearching ? this.searchData.results : [];
+  }
+
+  @restartableTask
+  *search(searchTerm) {
+    yield timeout(600);
+
+    let results = yield this.fetchAdministrativeUnits({ searchTerm });
+
+    this.searchData = new SearchData({
+      totalResultAmount: results.meta.count,
+      searchTerm: searchTerm,
+      results: results.toArray(),
+    });
+  }
+
+  @dropTask
+  *loadMoreSearchResults() {
+    if (this.isSearching) {
+      let results = yield this.fetchAdministrativeUnits({
+        searchTerm: this.searchData.searchTerm,
+        page: ++this.searchData.currentPage,
+      });
+
+      this.searchData.addSearchResults(results.toArray());
+    }
+  }
+
+  @action
+  registerAPI(api) {
+    // PowerSelect doesn't have an action to let us know when the search data is reset, so we use the registerAPI as a workaround.
+    // It get's called everytime any internal state has changed, so we can use it to detect when the searchText has cleared.
+    if (!api.searchText && this.searchData) {
+      this.searchData = null;
+    }
+  }
+
+  async fetchAdministrativeUnits({ searchTerm, page = 0 }) {
+    return this.store.query('bestuurseenheid', {
+      'filter[naam]': searchTerm,
+      sort: 'naam',
+      include: 'classificatie',
+      'page[number]': page,
+    });
+  }
+}
+
+class SearchData {
+  @tracked results = [];
+  currentPage = 0;
+
+  constructor({ totalResultAmount, searchTerm, results }) {
+    this.totalResultAmount = totalResultAmount;
+    this.searchTerm = searchTerm;
+    this.results = results;
+  }
+
+  get canLoadMoreSearchResults() {
+    return this.totalResultAmount > this.results.length;
+  }
+
+  addSearchResults(newResults = []) {
+    this.results = [...this.results, ...newResults];
+  }
+}

--- a/app/components/infinite-select/options.hbs
+++ b/app/components/infinite-select/options.hbs
@@ -1,0 +1,29 @@
+<div class="infinite-select-options">
+  <PowerSelect::Options
+    @loadingMessage={{@loadingMessage}}
+    @select={{@select}}
+    @options={{@options}}
+    @groupIndex=""
+    @optionsComponent={{@optionsComponent}}
+    @extra={{@extra}}
+    @highlightOnHover={{@highlightOnHover}}
+    @groupComponent={{@groupComponent}}
+    ...attributes
+    as |option select|
+  >
+    {{yield option select}}
+  </PowerSelect::Options>
+  {{#if @canLoadMore}}
+    <div class="au-o-box au-o-box--tiny">
+      <AuButton
+        @skin="secondary"
+        @width="block"
+        @loading={{if @isLoadingMore "true"}}
+        @disabled={{if @isLoadingMore "true"}}
+        {{on "click" @loadMore}}
+      >
+        {{t 'vendor.subject.modal.load-more'}}
+      </AuButton>
+    </div>
+  {{/if}}
+</div>

--- a/app/controllers/vendors/details.js
+++ b/app/controllers/vendors/details.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { task } from 'ember-concurrency-decorators';
 
 import { loadAllBestuurseenheidenForVendor } from 'frontend-vendor-access-management/utils/load-relation-utils';
 
@@ -16,13 +15,6 @@ export default class VendorsDetailsController extends Controller {
     await vendor.save();
     this.bestuurseenhedenLijst = [];
     this.send('reloadModel');
-  }
-
-  @task
-  *searchBestuursType(term){
-    let queryParams = {'filter[naam]': term};
-    yield
-    return this.store.query('bestuurseenheid', queryParams);
   }
 
   @action

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -1,3 +1,19 @@
 .au-c-modal__body{
   overflow: visible;
 }
+
+// "InfiniteSelect" component (this component should be made more generic and moved somewhere reusable)
+.infinite-select-options {
+  // Copied from ember-appuniversum: https://github.com/appuniversum/ember-appuniversum/blob/09fbccfa34190ab9552f42572d783d35e6925ad6/app/styles/ember-appuniversum/_p-ember-power-select.scss#L421-L424
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  @if unitless($ember-power-select-line-height) {
+    max-height: #{$ember-power-select-number-of-visible-options * $ember-power-select-line-height}em;
+  } @else {
+    max-height: $ember-power-select-number-of-visible-options * $ember-power-select-line-height;
+  }
+
+  .ember-power-select-options {
+    max-height: none;
+  }
+}

--- a/app/templates/vendors/details.hbs
+++ b/app/templates/vendors/details.hbs
@@ -28,7 +28,7 @@
       <AuToolbarGroup>
         <AuModal @buttonTitle={{t 'vendor.subject.table.button-1'}} @modalTitle="{{t 'vendor.subject.modal.head-1'}}">
           <AuModalBody>
-            <BestuurseenheidToevoegen @searchTask={{this.searchBestuursType}}
+            <BestuurseenheidToevoegen
               @onListBestuurseenheden={{this.listBestuurseenheden}}
               @appendBestuurseenheid={{this.appendBestuurseenheid}}
               @bestuurseenhedenLijst={{this.bestuurseenhedenLijst}}

--- a/translations/vendor/subject/en-us.yaml
+++ b/translations/vendor/subject/en-us.yaml
@@ -16,3 +16,4 @@ modal:
   head-2: Search for an administrative unit
   head-3: List
   button-1: Save
+  load-more: Load more administrative units

--- a/translations/vendor/subject/nl-be.yaml
+++ b/translations/vendor/subject/nl-be.yaml
@@ -16,3 +16,4 @@ modal:
   head-2: Zoek een Bestuurseenheid
   head-3: Lijst
   button-1: Opslaan
+  load-more: Meer bestuurseenheden laden


### PR DESCRIPTION
The search results are paginated by the server. Before this change not all options would be displayed and there was no option to load more. Some users couldn't find the option they needed and making the search term more specific isn't always possible.

This adds an extra button which users can click to manually load more search results.