### PR TITLE
Add a basic Woodpecker setup

### DIFF
--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,0 +1,10 @@
+pipeline:
+  build:
+    image: plugins/docker
+    settings:
+      repo: ${CI_REPO}
+      tags: latest
+    secrets: [ docker_username, docker_password ]
+when:
+  branch: master
+  event: push

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,0 +1,10 @@
+pipeline:
+  build:
+    image: plugins/docker
+    settings:
+      repo: ${CI_REPO}
+      tags: "${CI_COMMIT_TAG##v}"
+    secrets: [ docker_username, docker_password ]
+when:
+  event: tag
+  tag: v*

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -1,0 +1,9 @@
+pipeline:
+  build:
+    image: plugins/docker
+    settings:
+      repo: ${CI_REPO}
+      dry_run: true
+when:
+  event:
+    - pull_request


### PR DESCRIPTION
This setup only includes the Docker building part of our usual setup. The PR test pipeline still fails so it's not very useful at the moment. We can enable that once we give the apps more maintenance time.