### PR TITLE
Set up Embroider

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -38,12 +38,11 @@ module.exports = function (defaults) {
   compatAdapters.set('@ember-data/store', null);
 
   return require('@embroider/compat').compatBuild(app, Webpack, {
-    //
-    // staticAddonTestSupportTrees: true,
-    // staticAddonTrees: true,
-    // staticHelpers: true,
-    // staticModifiers: true,
-    // staticComponents: true,
+    staticAddonTestSupportTrees: true,
+    staticAddonTrees: true,
+    staticHelpers: true,
+    staticModifiers: true,
+    staticComponents: true,
     // splitAtRoutes: ['route.name'], // can also be a RegExp
     // packagerOptions: {
     //    webpackConfig: { }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,5 +26,32 @@ module.exports = function (defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  return app.toTree();
+  const { Webpack } = require('@embroider/webpack');
+
+  // The built-in compat adapters for Ember Data shouldn't be needed anymore.
+  // This code can be removed once https://github.com/embroider-build/embroider/pull/1369 is released.
+  const compatAdapters = new Map();
+  compatAdapters.set('ember-data', null);
+  compatAdapters.set('@ember-data/adapter', null);
+  compatAdapters.set('@ember-data/model', null);
+  compatAdapters.set('@ember-data/record-data', null);
+  compatAdapters.set('@ember-data/store', null);
+
+  return require('@embroider/compat').compatBuild(app, Webpack, {
+    //
+    // staticAddonTestSupportTrees: true,
+    // staticAddonTrees: true,
+    // staticHelpers: true,
+    // staticModifiers: true,
+    // staticComponents: true,
+    // splitAtRoutes: ['route.name'], // can also be a RegExp
+    // packagerOptions: {
+    //    webpackConfig: { }
+    // }
+    //
+
+    packageRules: [{ '@ember-data/store': null }],
+    compatAdapters,
+    extraPublicTrees: [],
+  });
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
+    "@embroider/compat": "^2.0.0",
+    "@embroider/core": "^2.0.0",
+    "@embroider/webpack": "^2.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@lblod/ember-mock-login": "^0.7.0",
@@ -51,9 +55,10 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^2.3.7",
-    "ember-data": "~4.8.0",
+    "ember-data": "~4.11.0",
     "ember-data-table": "^2.1.0",
     "ember-fetch": "^8.1.2",
+    "ember-focus-trap": "^1.0.1",
     "ember-intl": "^5.5.0",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
@@ -76,7 +81,12 @@
     "qunit-dom": "^2.0.0",
     "release-it": "^15.5.0",
     "sass": "^1.26.11",
-    "webpack": "^5.75.0"
+    "webpack": "^5.67.0"
+  },
+  "devDependenciesNotes": {
+    "@ember/string": "some addons list this as a peerDependency, we can remove it again once those addons switch to a different package",
+    "ember-focus-trap": "Appuniversum uses this, but there is an Embroider issue that prevents it from building without listing it as a dep ourselves: https://github.com/embroider-build/embroider/issues/1175",
+    "ember-data": "We install v4.11 here since older versions don't want to build under Embroider, even after disabling the package rules and adapters"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
This sets up Embroider with the strictest compat config which leads to some nice build size improvements:

<details>
  <summary>Embroider strict</summary>

```
  File sizes:
 - dist/assets/chunk.01cc2bf8b54e975ad2ac.js: 662.78 kB (175.42 kB gzipped)
 - dist/assets/chunk.c7668f8168e598770d8c.js: 54.9 kB (11.02 kB gzipped)
 - dist/assets/frontend-vendor-access-management.2b9807636a4809a9071e68f3dbb62f00.css: 135.11 kB (19.26 kB gzipped)
 - dist/assets/vendor.36dc9b7e392c85902e744f4949161ef4.js: 451.58 kB (126.3 kB gzipped)
```
</details>

<details>
  <summary>Embroider compat</summary>

```
File sizes:
 - dist/assets/chunk.059b350d270201d1230c.js: 137.15 kB (22.93 kB gzipped)
 - dist/assets/chunk.0ede0699c30569f3c017.js: 53.8 kB (17.35 kB gzipped)
 - dist/assets/chunk.682b32a94dc6698031f8.js: 5.01 kB (2.15 kB gzipped)
 - dist/assets/chunk.aa3ac6d4ada8319a1684.js: 821.17 kB (205.16 kB gzipped)
 - dist/assets/chunk.e1f6063836d299820ca2.js: 317 B (243 B gzipped)
 - dist/assets/frontend-vendor-access-management.2b9807636a4809a9071e68f3dbb62f00.css: 135.11 kB (19.26 kB gzipped)
 - dist/assets/vendor.36dc9b7e392c85902e744f4949161ef4.js: 451.58 kB (126.3 kB gzipped)
```
</details>

<details>
  <summary>Classic build</summary>

```
 File sizes:
 - dist/assets/chunk.143.b3b3c5b39aa179f98d3e.js: 5.45 kB (2.18 kB gzipped)
 - dist/assets/chunk.178.93e03ead09a58b2f2003.js: 1.89 kB (890 B gzipped)
 - dist/assets/chunk.410.7811f9bb357a46ec5408.js: 53.75 kB (17.53 kB gzipped)
 - dist/assets/chunk.642.3b440cc3bfa0c0e1fbc1.js: 253.47 kB (73.45 kB gzipped)
 - dist/assets/chunk.810.22370c7058ac37b1a506.js: 5 kB (2.15 kB gzipped)
 - dist/assets/chunk.958.d455cdd2a4e056b0599f.js: 87.73 kB (28.48 kB gzipped)
 - dist/assets/chunk.993.b40e681b19b6dc9e3061.js: 299 B (236 B gzipped)
 - dist/assets/frontend-vendor-access-management-00ef89a60f25ba7340a9921b1ee58fb9.js: 133.34 kB (14.54 kB gzipped)
 - dist/assets/frontend-vendor-access-management-c3c8806615334130c13a96b798a655ad.css: 131.17 kB (19.21 kB gzipped)
 - dist/assets/vendor-b1b3bc3be3f0c10c1fe7c0c13fd50db8.js: 1.13 MB (265.5 kB gzipped)
 - dist/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css: 0 B
```
</details>