### PR TITLE
Set view only modules

### DIFF
--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -56,7 +56,7 @@
             <Group.Checkbox
               @value={{modeValue}}
               {{on "change" this.changeViewOnlyModules}}>
-              {{t (concat "vendor.subject.modules." modeKey)}}
+              {{t modeKey}}
             </Group.Checkbox>
           {{/each-in}}
         </AuCheckboxGroup>

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -20,7 +20,9 @@
       isLoadingMore=this.loadMoreSearchResults.isRunning
     }}
     @registerAPI={{this.registerAPI}}
-    @onChange={{@appendBestuurseenheid}} as |eenheid|>
+    @onChange={{this.setOption}}
+    as |eenheid|>
+    {{!-- @onChange={{@appendBestuurseenheid}} --}}
       {{eenheid.naam}} ({{eenheid.classificatie.label}})
   </PowerSelect>
 

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -51,11 +51,10 @@
         </p>
         <AuCheckboxGroup
           @selected={{this.selectedViewOnlyModules}}
+          @onChange={{this.changeViewOnlyModules}}
           as |Group|>
           {{#each-in this.viewOnlyModules as |modeKey modeValue|}}
-            <Group.Checkbox
-              @value={{modeValue}}
-              {{on "change" this.changeViewOnlyModules}}>
+            <Group.Checkbox @value={{modeValue}}>
               {{t modeKey}}
             </Group.Checkbox>
           {{/each-in}}

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -1,33 +1,28 @@
 <div class="au-o-flow">
-  <AuCard @flex="true" as |c|>
-    <c.header>
-      <AuHeading @level="2" @skin="4" id="describe-search">
-        {{t 'vendor.subject.modal.head-2'}}
-      </AuHeading>
-    </c.header>
-    <c.content>
-      <PowerSelect
-        @ariaLabel="Zoekbalk"
-        @search={{perform this.search}}
-        @options={{this.options}}
-        @allowClear={{true}}
-        @searchEnabled={{true}}
-        @loadingMessage="Aan het laden..."
-        @searchMessage="Typ om te zoeken"
-        @noMatchesMessage="Geen resultaten"
-        @optionsComponent={{component
-          "infinite-select/options"
-          canLoadMore=this.searchData.canLoadMoreSearchResults
-          loadMore=(perform this.loadMoreSearchResults)
-          isLoadingMore=this.loadMoreSearchResults.isRunning
-        }}
-        @registerAPI={{this.registerAPI}}
-        @renderInPlace={{true}}
-        @onChange={{@appendBestuurseenheid}} as |eenheid|>
-          {{eenheid.naam}} ({{eenheid.classificatie.label}})
-      </PowerSelect>
-    </c.content>
-  </AuCard>
+  <AuHeading @level="2" @skin="4" id="describe-search">
+    {{t 'vendor.subject.modal.head-2'}}
+  </AuHeading>
+  <PowerSelect
+    @ariaLabel="Zoekbalk"
+    @allowClear={{true}}
+    @renderInPlace={{true}}
+    @searchEnabled={{true}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @searchMessage="Typ om te zoeken"
+    @options={{this.options}}
+    @selected={{this.selected}}
+    @search={{perform this.search}}
+    @optionsComponent={{component
+      "infinite-select/options"
+      canLoadMore=this.searchData.canLoadMoreSearchResults
+      loadMore=(perform this.loadMoreSearchResults)
+      isLoadingMore=this.loadMoreSearchResults.isRunning
+    }}
+    @registerAPI={{this.registerAPI}}
+    @onChange={{@appendBestuurseenheid}} as |eenheid|>
+      {{eenheid.naam}} ({{eenheid.classificatie.label}})
+  </PowerSelect>
 
   <AuCard @flex="true" as |c|>
     <c.header>

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -22,7 +22,6 @@
     @registerAPI={{this.registerAPI}}
     @onChange={{this.setOption}}
     as |eenheid|>
-    {{!-- @onChange={{@appendBestuurseenheid}} --}}
       {{eenheid.naam}} ({{eenheid.classificatie.label}})
   </PowerSelect>
 

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -26,21 +26,38 @@
       {{eenheid.naam}} ({{eenheid.classificatie.label}})
   </PowerSelect>
 
-  <AuCard @flex="true" as |c|>
-    <c.header>
-      <AuHeading @level="2" @skin="4">
-        {{t 'vendor.subject.modal.head-3'}}
-      </AuHeading>
-    </c.header>
-
-    <c.content>
-        <div>
-          {{#each @bestuurseenhedenLijst as |eenheid|}}
-            <AuPill class="au-u-margin-bottom-small">
-                {{eenheid.naam}}  <AuIcon @icon="cross" @size="medium" {{on 'click' (fn @removeBestuurseenheid eenheid) }}/>
-            </AuPill>
-          {{/each}}
-        </div>
-    </c.content>
-  </AuCard>
+  {{#if this.selected}}
+    <AuCard
+      @flex={{true}}
+      @textCenter={{false}}
+      @shadow={{false}}
+      @size="regular"
+      @standOut={{true}}
+      @expandable={{false}}
+      @isExpanded={{true}}
+      @isOpenInitially={{true}}
+      @manualControl={{false}}
+      as |c|>
+      <c.header>
+        <AuHeading @level="2" @skin="3">
+          {{this.selected.naam}}
+        </AuHeading>
+        <p class="au-u-italic">
+          {{this.selected.classificatie.label}}
+        </p>
+      </c.header>
+      <c.content>
+        <p>
+          {{t "vendor.subject.modal.body-1"}}
+        </p>
+        <AuCheckboxGroup as |Group|>
+          {{#each-in this.viewOnlyModules as |modeKey modeValue|}}
+            <Group.Checkbox @value={{modeValue}}>
+              {{t (string-concat "vendor.subject.modules." modeKey)}}
+            </Group.Checkbox>
+          {{/each-in}}
+        </AuCheckboxGroup>
+      </c.content>
+    </AuCard>
+  {{/if}}
 </div>

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -56,7 +56,7 @@
             <Group.Checkbox
               @value={{modeValue}}
               {{on "change" this.changeViewOnlyModules}}>
-              {{t (string-concat "vendor.subject.modules." modeKey)}}
+              {{t (concat "vendor.subject.modules." modeKey)}}
             </Group.Checkbox>
           {{/each-in}}
         </AuCheckboxGroup>

--- a/app/components/bestuurseenheid-toevoegen.hbs
+++ b/app/components/bestuurseenheid-toevoegen.hbs
@@ -50,9 +50,13 @@
         <p>
           {{t "vendor.subject.modal.body-1"}}
         </p>
-        <AuCheckboxGroup as |Group|>
+        <AuCheckboxGroup
+          @selected={{this.selectedViewOnlyModules}}
+          as |Group|>
           {{#each-in this.viewOnlyModules as |modeKey modeValue|}}
-            <Group.Checkbox @value={{modeValue}}>
+            <Group.Checkbox
+              @value={{modeValue}}
+              {{on "change" this.changeViewOnlyModules}}>
               {{t (string-concat "vendor.subject.modules." modeKey)}}
             </Group.Checkbox>
           {{/each-in}}

--- a/app/components/bestuurseenheid-toevoegen.js
+++ b/app/components/bestuurseenheid-toevoegen.js
@@ -3,8 +3,10 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
+import { VIEW_ONLY_MODES } from '/utils/constants';
 
 export default class BestuurseenheidToevoegenComponent extends Component {
+  viewOnlyModules = VIEW_ONLY_MODES;
   @service store;
 
   @tracked selected = undefined;

--- a/app/components/bestuurseenheid-toevoegen.js
+++ b/app/components/bestuurseenheid-toevoegen.js
@@ -7,10 +7,16 @@ import { VIEW_ONLY_MODES } from '/utils/constants';
 
 export default class BestuurseenheidToevoegenComponent extends Component {
   viewOnlyModules = VIEW_ONLY_MODES;
+  selectedViewOnlyModulesSet = new Set();
+
   @service store;
 
   @tracked selected = undefined;
   @tracked searchData;
+
+  get selectedViewOnlyModules() {
+    return [...this.selectedViewOnlyModulesSet];
+  }
 
   get isSearching() {
     return Boolean(this.searchData);
@@ -21,7 +27,6 @@ export default class BestuurseenheidToevoegenComponent extends Component {
       return [];
     }
 
-    //TODO filter through a different list, we're not using pre lists anymore
     return this.searchData.results.filter((bestuurseenheid) => {
       return !this.args.bestuurseenhedenLijst.includes(bestuurseenheid);
     });
@@ -30,6 +35,21 @@ export default class BestuurseenheidToevoegenComponent extends Component {
   @action
   setOption(selected) {
     this.selected = selected;
+    this.changedBestuurseenheid();
+  }
+
+  @action
+  changeViewOnlyModules(event) {
+    if (event.target.checked)
+      this.selectedViewOnlyModulesSet.add(event.target.value);
+    else this.selectedViewOnlyModulesSet.delete(event.target.value);
+    this.changedBestuurseenheid();
+  }
+
+  @action
+  changedBestuurseenheid() {
+    this.selected.viewOnlyModules = this.selectedViewOnlyModules;
+    this.args.onSelect(this.selected);
   }
 
   @restartableTask

--- a/app/components/bestuurseenheid-toevoegen.js
+++ b/app/components/bestuurseenheid-toevoegen.js
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
-import { VIEW_ONLY_MODES } from '/utils/constants';
+import { VIEW_ONLY_MODES } from 'frontend-vendor-access-management/utils/constants';
 
 export default class BestuurseenheidToevoegenComponent extends Component {
   viewOnlyModules = VIEW_ONLY_MODES;

--- a/app/components/bestuurseenheid-toevoegen.js
+++ b/app/components/bestuurseenheid-toevoegen.js
@@ -39,7 +39,7 @@ export default class BestuurseenheidToevoegenComponent extends Component {
   }
 
   @action
-  changeViewOnlyModules(event) {
+  changeViewOnlyModules(values, event) {
     if (event.target.checked)
       this.selectedViewOnlyModulesSet.add(event.target.value);
     else this.selectedViewOnlyModulesSet.delete(event.target.value);

--- a/app/components/bestuurseenheid-toevoegen.js
+++ b/app/components/bestuurseenheid-toevoegen.js
@@ -7,7 +7,7 @@ import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 export default class BestuurseenheidToevoegenComponent extends Component {
   @service store;
 
-  @tracked selected = null;
+  @tracked selected = undefined;
   @tracked searchData;
 
   get isSearching() {
@@ -19,9 +19,15 @@ export default class BestuurseenheidToevoegenComponent extends Component {
       return [];
     }
 
+    //TODO filter through a different list, we're not using pre lists anymore
     return this.searchData.results.filter((bestuurseenheid) => {
       return !this.args.bestuurseenhedenLijst.includes(bestuurseenheid);
     });
+  }
+
+  @action
+  setOption(selected) {
+    this.selected = selected;
   }
 
   @restartableTask

--- a/app/controllers/vendors/details/index.js
+++ b/app/controllers/vendors/details/index.js
@@ -9,11 +9,11 @@ export default class VendorsDetailsIndexController extends Controller {
   @service router;
   @service store;
   @tracked vendor;
-  @tracked bestuurseenhedenLijst = [];
   @tracked isAddingAdministrativeUnits = false;
   @tracked bestuurseenheidToRemove;
   @tracked filter = '';
   @tracked page = 0;
+  selectedNewBestuurseenheid;
   sort = 'naam';
   size = 20;
 
@@ -32,17 +32,13 @@ export default class VendorsDetailsIndexController extends Controller {
     this.hideDeleteConfirmationModal(true);
   };
 
-    await Promise.all(
-      this.bestuurseenhedenLijst.map(async (bestuurseenheid) => {
-        const vendors = await bestuurseenheid.vendors;
-        vendors.push(this.vendor);
-        await bestuurseenheid.save();
-      })
-    );
   @dropTask
   *addToList() {
+    const vendorsForBestuurseenheid = yield this.selectedNewBestuurseenheid.vendors;
+    vendorsForBestuurseenheid.push(this.vendor);
+    yield this.selectedNewBestuurseenheid.save();
+    this.selectedNewBestuurseenheid = undefined;
 
-    this.bestuurseenhedenLijst = [];
     this.router.refresh('vendors.details');
     this.closeAddModal();
   };
@@ -56,13 +52,8 @@ export default class VendorsDetailsIndexController extends Controller {
   };
 
   @action
-  async appendBestuurseenheid(eenheid) {
-    this.bestuurseenhedenLijst.pushObject(eenheid);
-  }
-
-  @action
-  removeBestuurseenheid(eenheid) {
-    this.bestuurseenhedenLijst = this.bestuurseenhedenLijst.without(eenheid);
+  selectNewBestuurseenheid(bestuurseenheid) {
+    this.selectedNewBestuurseenheid = bestuurseenheid;
   }
 
   @action

--- a/app/controllers/vendors/details/index.js
+++ b/app/controllers/vendors/details/index.js
@@ -25,6 +25,7 @@ export default class VendorsDetailsIndexController extends Controller {
     const bestuurseenheid = this.bestuurseenheidToRemove;
     const vendors = await bestuurseenheid.vendors;
     vendors.splice(vendors.indexOf(this.vendor), 1);
+    bestuurseenheid.viewOnlyModules = [];
     await bestuurseenheid.save();
     //We must trigger model(), since the pagination depends on this.
     await this.router.refresh('vendors.details.index');

--- a/app/controllers/vendors/details/index.js
+++ b/app/controllers/vendors/details/index.js
@@ -28,7 +28,7 @@ export default class VendorsDetailsIndexController extends Controller {
     vendors.splice(vendors.indexOf(this.vendor), 1);
     yield bestuurseenheid.save();
     //We must trigger model(), since the pagination depends on this.
-    this.router.refresh('vendors.details.index');
+    yield this.router.refresh('vendors.details.index');
     this.hideDeleteConfirmationModal(true);
   };
 

--- a/app/controllers/vendors/details/index.js
+++ b/app/controllers/vendors/details/index.js
@@ -30,18 +30,19 @@ export default class VendorsDetailsIndexController extends Controller {
     //We must trigger model(), since the pagination depends on this.
     yield this.router.refresh('vendors.details.index');
     this.hideDeleteConfirmationModal(true);
-  };
+  }
 
   @dropTask
   *addToList() {
-    const vendorsForBestuurseenheid = yield this.selectedNewBestuurseenheid.vendors;
+    const vendorsForBestuurseenheid = yield this.selectedNewBestuurseenheid
+      .vendors;
     vendorsForBestuurseenheid.push(this.vendor);
     yield this.selectedNewBestuurseenheid.save();
     this.selectedNewBestuurseenheid = undefined;
 
     this.router.refresh('vendors.details');
     this.closeAddModal();
-  };
+  }
 
   @dropTask
   *search(searchValue) {
@@ -49,7 +50,7 @@ export default class VendorsDetailsIndexController extends Controller {
 
     this.filter = searchValue.trim();
     this.resetPagination();
-  };
+  }
 
   @action
   selectNewBestuurseenheid(bestuurseenheid) {

--- a/app/helpers/string-concat.js
+++ b/app/helpers/string-concat.js
@@ -1,5 +1,0 @@
-import { helper } from '@ember/component/helper';
-
-export default helper(function stringConcat(positional /*, named*/) {
-  return positional.join('');
-});

--- a/app/helpers/string-concat.js
+++ b/app/helpers/string-concat.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function stringConcat(positional /*, named*/) {
+  return positional.join('');
+});

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -1,6 +1,10 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import { service } from '@ember/service';
+import { VIEW_ONLY_MODES } from '/utils/constants';
 
 export default class BestuurseenheidModel extends Model {
+  @service intl;
+
   @attr uri;
   @attr naam;
   @attr alternatieveNaam;
@@ -18,4 +22,20 @@ export default class BestuurseenheidModel extends Model {
     as: 'bestuurseenheid',
   })
   vendors;
+
+  get hasViewOnlyModules() {
+    return this.viewOnlyModules && this.viewOnlyModules.length > 0;
+  }
+
+  get formattedViewOnlyModules() {
+    if (this.viewOnlyModules)
+      return this.viewOnlyModules
+        .map((value) => {
+          for (const key in VIEW_ONLY_MODES)
+            if (VIEW_ONLY_MODES[key] === value) return key;
+        })
+        .map((key) => this.intl.t('vendor.subject.modules.' + key))
+        .join(', ');
+    else return '';
+  }
 }

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -1,6 +1,6 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { service } from '@ember/service';
-import { VIEW_ONLY_MODES } from '/utils/constants';
+import { VIEW_ONLY_MODES } from 'frontend-vendor-access-management/utils/constants';
 
 export default class BestuurseenheidModel extends Model {
   @service intl;

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -4,11 +4,14 @@ export default class BestuurseenheidModel extends Model {
   @attr uri;
   @attr naam;
   @attr alternatieveNaam;
+  @attr viewOnlyModules;
+
   @belongsTo('bestuurseenheid-classificatie-code', {
     async: true,
     inverse: null,
   })
   classificatie;
+
   @hasMany('vendor', {
     async: true,
     inverse: 'canActOnBehalfOf',

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -34,7 +34,7 @@ export default class BestuurseenheidModel extends Model {
           for (const key in VIEW_ONLY_MODES)
             if (VIEW_ONLY_MODES[key] === value) return key;
         })
-        .map((key) => this.intl.t('vendor.subject.modules.' + key))
+        .map((key) => this.intl.t(key))
         .join(', ');
     else return '';
   }

--- a/app/templates/vendors/details/index.hbs
+++ b/app/templates/vendors/details/index.hbs
@@ -82,9 +82,10 @@
     @isLoading={{this.isLoading}} as |f|>
     <f.content as |c|>
       <c.header>
-          <AuDataTableThSortable @field="naam" @currentSorting={{this.sort}} @label={{t 'vendor.subject.table.row-1'}} @class="data-table__header-title" />
-          <AuDataTableThSortable @field="classificatie.label" @currentSorting={{this.sort}} @label={{t 'vendor.subject.table.row-2'}} @class="data-table__header-title" />
-        <th class="data-table__header-title u-visible--tablet-portrait-up" style="max-width: 5rem;" {{!template-lint-disable no-inline-styles}}>{{t 'vendor.subject.table.row-3'}}</th>
+        <AuDataTableThSortable @field="naam" @currentSorting={{this.sort}} @label={{t 'vendor.subject.table.row-1'}} @class="data-table__header-title" />
+        <AuDataTableThSortable @field="classificatie.label" @currentSorting={{this.sort}} @label={{t 'vendor.subject.table.row-2'}} @class="data-table__header-title" />
+        <th class="data-table__header-title u-visible--tablet-portrait-up">{{t 'vendor.subject.table.row-3'}}</th>
+        <th class="data-table__header-title u-visible--tablet-portrait-up" style="max-width: 5rem;" {{!template-lint-disable no-inline-styles}}>{{t 'vendor.subject.table.row-4'}}</th>
       </c.header>
       <c.body as |bestuurseenheid|>
         <td>
@@ -92,6 +93,9 @@
         </td>
         <td>
           {{bestuurseenheid.classificatie.label}}
+        </td>
+        <td>
+          {{bestuurseenheid.viewOnlyModules}}
         </td>
         <td>
           <AuButton @alert="true" @skin="link" @icon="link-broken" {{ on 'click' (fn this.showDeleteConfirmationModal bestuurseenheid)}}>

--- a/app/templates/vendors/details/index.hbs
+++ b/app/templates/vendors/details/index.hbs
@@ -95,7 +95,13 @@
           {{bestuurseenheid.classificatie.label}}
         </td>
         <td>
-          {{bestuurseenheid.viewOnlyModules}}
+          {{#if bestuurseenheid.hasViewOnlyModules}}
+            {{bestuurseenheid.formattedViewOnlyModules}}
+          {{else}}
+            <p class="au-u-muted au-u-italic">
+              {{t "vendor.subject.modules.none"}}
+            </p>
+          {{/if}}
         </td>
         <td>
           <AuButton @alert="true" @skin="link" @icon="link-broken" {{ on 'click' (fn this.showDeleteConfirmationModal bestuurseenheid)}}>

--- a/app/templates/vendors/details/index.hbs
+++ b/app/templates/vendors/details/index.hbs
@@ -114,12 +114,14 @@
     </:title>
     <:body>
       <BestuurseenheidToevoegen
-        @appendBestuurseenheid={{this.appendBestuurseenheid}}
-        @bestuurseenhedenLijst={{this.bestuurseenhedenLijst}}
-        @removeBestuurseenheid={{this.removeBestuurseenheid}} />
+        @bestuurseenhedenLijst={{this.model}}
+        @onSelect={{this.selectNewBestuurseenheid}}/>
     </:body>
     <:footer>
-      <AuButton @loading={{this.addToList.isRunning}} @loadingMessage={{t "loading.add"}} {{ on 'click' (perform this.addToList)}}>
+      <AuButton
+        @loading={{this.addToList.isRunning}}
+        @loadingMessage={{t "loading.add"}}
+        {{on "click" (perform this.addToList)}}>
         {{t 'vendor.subject.modal.button-1'}}
       </AuButton>
     </:footer>

--- a/app/templates/vendors/details/index.hbs
+++ b/app/templates/vendors/details/index.hbs
@@ -110,7 +110,6 @@
     </:title>
     <:body>
       <BestuurseenheidToevoegen
-        @onListBestuurseenheden={{this.listBestuurseenheden}}
         @appendBestuurseenheid={{this.appendBestuurseenheid}}
         @bestuurseenhedenLijst={{this.bestuurseenhedenLijst}}
         @removeBestuurseenheid={{this.removeBestuurseenheid}} />

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,0 +1,4 @@
+export const VIEW_ONLY_MODES = {
+  'tWorshipMinisters': 'LoketLB-eredienstBedienaarGebruiker',
+  'tWorshipMandates': 'LoketLB-eredienstMandaatGebruiker',
+};

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,4 +1,6 @@
 export const VIEW_ONLY_MODES = {
-  tWorshipMinisters: 'LoketLB-eredienstBedienaarGebruiker',
-  tWorshipMandates: 'LoketLB-eredienstMandaatGebruiker',
+  'vendor.subject.modules.worship-ministers':
+    'LoketLB-eredienstBedienaarGebruiker',
+  'vendor.subject.modules.worship-mandates':
+    'LoketLB-eredienstMandaatGebruiker',
 };

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,4 +1,4 @@
 export const VIEW_ONLY_MODES = {
-  'tWorshipMinisters': 'LoketLB-eredienstBedienaarGebruiker',
-  'tWorshipMandates': 'LoketLB-eredienstMandaatGebruiker',
+  tWorshipMinisters: 'LoketLB-eredienstBedienaarGebruiker',
+  tWorshipMandates: 'LoketLB-eredienstMandaatGebruiker',
 };

--- a/translations/vendor/subject/en-us.yaml
+++ b/translations/vendor/subject/en-us.yaml
@@ -10,7 +10,8 @@ table:
   not-found: No administrative units assigned.
   row-1: Administrative unit
   row-2: Type
-  row-3: Action
+  row-3: Allow editing
+  row-4: Action
 modal:
   head-1: Add administrative unit
   head-2: Search for an administrative unit

--- a/translations/vendor/subject/en-us.yaml
+++ b/translations/vendor/subject/en-us.yaml
@@ -10,7 +10,7 @@ table:
   not-found: No administrative units assigned.
   row-1: Administrative unit
   row-2: Type
-  row-3: Allow editing
+  row-3: View only modules
   row-4: Action
 modal:
   head-1: Add administrative unit
@@ -21,5 +21,6 @@ modal:
 delete-modal:
   title: Remove access rights
 modules:
+  none: All editable
   tWorshipMinisters: Worship Minister Management
   tWorshipMandates: Worship Mandate Management

--- a/translations/vendor/subject/en-us.yaml
+++ b/translations/vendor/subject/en-us.yaml
@@ -15,8 +15,11 @@ table:
 modal:
   head-1: Add administrative unit
   head-2: Search for an administrative unit
-  head-3: List
   button-1: Save
   load-more: Load more administrative units
+  body-1: Select the modules for which to activate read-only modes.
 delete-modal:
   title: Remove access rights
+modules:
+  tWorshipMinisters: Worship Minister Management
+  tWorshipMandates: Worship Mandate Management

--- a/translations/vendor/subject/en-us.yaml
+++ b/translations/vendor/subject/en-us.yaml
@@ -22,5 +22,5 @@ delete-modal:
   title: Remove access rights
 modules:
   none: All editable
-  tWorshipMinisters: Worship Minister Management
-  tWorshipMandates: Worship Mandate Management
+  worship-ministers: Worship Minister Management
+  worship-mandates: Worship Mandate Management

--- a/translations/vendor/subject/nl-be.yaml
+++ b/translations/vendor/subject/nl-be.yaml
@@ -10,7 +10,7 @@ table:
   not-found: Geen bestuurseenheden aangewezen.
   row-1: Bestuurseenheid
   row-2: Type
-  row-3: Bewerken toestaan
+  row-3: Alleen-lezen modules
   row-4: Actie
 modal:
   head-1: Bestuurseenheid Toevoegen
@@ -21,5 +21,6 @@ modal:
 delete-modal:
   title: Toegangsrechten verwijderen
 modules:
+  none: Allemaal bewerkbaar
   tWorshipMinisters: Eredienst Bedienarenbeheer
   tWorshipMandates: Eredients Mandatenbeheer

--- a/translations/vendor/subject/nl-be.yaml
+++ b/translations/vendor/subject/nl-be.yaml
@@ -22,5 +22,5 @@ delete-modal:
   title: Toegangsrechten verwijderen
 modules:
   none: Allemaal bewerkbaar
-  tWorshipMinisters: Eredienst Bedienarenbeheer
-  tWorshipMandates: Eredients Mandatenbeheer
+  worship-ministers: Eredienst Bedienarenbeheer
+  worship-mandates: Eredients Mandatenbeheer

--- a/translations/vendor/subject/nl-be.yaml
+++ b/translations/vendor/subject/nl-be.yaml
@@ -10,7 +10,8 @@ table:
   not-found: Geen bestuurseenheden aangewezen.
   row-1: Bestuurseenheid
   row-2: Type
-  row-3: Actie
+  row-3: Bewerken toestaan
+  row-4: Actie
 modal:
   head-1: Bestuurseenheid Toevoegen
   head-2: Zoek een Bestuurseenheid

--- a/translations/vendor/subject/nl-be.yaml
+++ b/translations/vendor/subject/nl-be.yaml
@@ -15,8 +15,11 @@ table:
 modal:
   head-1: Bestuurseenheid Toevoegen
   head-2: Zoek een Bestuurseenheid
-  head-3: Lijst
   button-1: Opslaan
   load-more: Meer bestuurseenheden laden
+  body-1: Selecteer voor welke modules alleen-lezen modus te activeren.
 delete-modal:
   title: Toegangsrechten verwijderen
+modules:
+  tWorshipMinisters: Eredienst Bedienarenbeheer
+  tWorshipMandates: Eredients Mandatenbeheer


### PR DESCRIPTION
DL-5012

See https://github.com/lblod/app-digitaal-loket/pull/402 for needed changes in Loket.

Introducing the ability to set view-only modules (for Loket) via the Vendor Management. When adding a bestuurseenheid to a vendor, you get the ability to choose from some modules to set them to read-only to not allow updates in Loket.

For this I had to remove the list where you could add multiple bestuurseenheden before saving. Since the search is so slow, it didn't make much sense to me to keep it. Keeping it in combination with having the necessary UI elements for the modules would make this overly complicated. You can now add only one bestuurseenheid at a time.

![image](https://user-images.githubusercontent.com/12394202/234734613-44c7b5cb-d819-427b-82a4-37c3af29176f.png)
![image](https://user-images.githubusercontent.com/12394202/234734671-d84b1583-1c91-4a92-bf1d-ca796785ac65.png)
