### PR TITLE
Search filter fix

### DIFF
--- a/app/controllers/vendors/details/index.js
+++ b/app/controllers/vendors/details/index.js
@@ -43,7 +43,7 @@ export default class VendorsDetailsIndexController extends Controller {
     this.closeAddModal();
   });
 
-  search = task({ drop: true }, async (searchValue) => {
+  search = task({ restartable: true }, async (searchValue) => {
     await timeout(500);
 
     this.filter = searchValue.trim();


### PR DESCRIPTION
We were using a `drop` task instead of a restartable one, which resulted in the search query starting to soon and any extra characters being ignored.