### PR TITLE
Use the `semtech/static-file-service` as a base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM semtech/ember-proxy-service:1.5.1
+FROM semtech/static-file-service:0.2.0
 
-ENV STATIC_FOLDERS_REGEX "^/(assets|font|files|handleiding|toezicht/bestanden|@appuniversum)/"
-
-COPY --from=builder /app/dist /app
+COPY --from=builder /app/dist /data


### PR DESCRIPTION
The `semtech/ember-proxy-service` image is deprecated.

https://github.com/mu-semtech/static-file-service?tab=readme-ov-file#getting-started

Breaking change since it requires the host app to change the way it is integrated.